### PR TITLE
Use polyfill for Ember.assign and support Ember 1.13+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-2.0
+  - EMBER_TRY_SCENARIO=ember-2.4
+  - EMBER_TRY_SCENARIO=ember-2.5
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/utils/update.js
+++ b/addon/utils/update.js
@@ -1,7 +1,7 @@
-
 import Ember from 'ember';
+import assign from 'ember-assign-polyfill';
 
-const { get, setProperties, assign } = Ember;
+const { get, setProperties } = Ember;
 
 // Usage: update(person, 'name', (name) => name.toUpperCase())
 export default function update(obj, key, updateFn) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,6 +8,39 @@ module.exports = {
       }
     },
     {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          'ember': '~1.13.0'
+        },
+        resolutions: {
+          'ember': '~1.13.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2.0',
+      bower: {
+        dependencies: {
+          'ember': '~2.0.0'
+        },
+        resolutions: {
+          'ember': '~2.0.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2.4',
+      bower: {
+        dependencies: {
+          'ember': '~2.4.0'
+        },
+        resolutions: {
+          'ember': '~2.4.0'
+        }
+      }
+    },
+    {
       name: 'ember-2.5',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "emberjs"
   ],
   "dependencies": {
+    "ember-assign-polyfill": "1.0.0",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
Apps using Ember 2.4 or lower were previously unable to use this because of its reliance on `Ember.assign` (which was added in [Ember 2.5](http://emberjs.com/blog/2016/04/11/ember-2-5-released.html#toc_changes-in-ember-2-5)).

Luckily, a pretty simple polyfill already exists, so we're just relying on that now :)
