### PR TITLE
remove assign logic

### DIFF
--- a/addon/utils/update.js
+++ b/addon/utils/update.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 
-const { get, setProperties, assign } = Ember;
+const { get, set, assign } = Ember;
 
 // Usage: update(person, 'name', (name) => name.toUpperCase())
 export default function update(obj, key, updateFn) {
   let property = get(obj, key);
   let newValue = updateFn(property);
-  let newObject = assign({}, obj, { [key]: newValue });
-  setProperties(obj, newObject);
+  set(obj, key, newValue);
 }


### PR DESCRIPTION
In a couple projects I use this `update` util:

```js
export default function(obj, key, transformFunc) {
    let oldValue = get(obj, key);
    let newValue = transformFunc(oldValue);
    set(obj, key, newValue);
}
```

I would love to switch over to your addon, but I think the `assign` and `setProperties` is overkill. If you accept this I will switch over.